### PR TITLE
Add Express proxy backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,38 @@ VITE_ENVIRONMENT=production
 
 For deployment instructions, see our [Deployment Guide](docs/DEPLOYMENT.md).
 
+### Backend API Proxy
+
+ALGORANARCHY now includes a lightweight Express.js backend used to bypass CORS
+restrictions for Tinyman, Pact and Vestige DEX APIs.
+
+#### Running Locally
+
+```bash
+# Start the proxy server
+cd server && npm install
+npm start
+```
+
+The proxy listens on `http://localhost:3000` and exposes `/api/tinyman/*`,
+`/api/pact/*` and `/api/vestige/*` routes.
+
+Environment variables for Algorand API tokens should be defined without the
+`VITE_` prefix, for example:
+
+```env
+ALGO_API_TOKEN=your_algorand_api_token
+TINYMAN_API_TOKEN=optional_tinyman_token
+PACT_API_TOKEN=optional_pact_token
+VESTIGE_API_TOKEN=optional_vestige_token
+```
+
+#### Production Deployment
+
+Deploy the `server/` folder to your preferred Node.js hosting platform
+(Render, Vercel, etc.). Ensure the same environment variables are configured and
+update your frontend to point to the deployed backend URL.
+
 ## 🔧 Troubleshooting
 
 ### Common Issues

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,50 @@
+import express from 'express';
+import axios from 'axios';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+const TINYMAN_API_URL = process.env.TINYMAN_API_URL || 'https://mainnet.analytics.tinyman.org';
+const PACT_API_URL = process.env.PACT_API_URL || 'https://api.pact.fi';
+const VESTIGE_API_URL = process.env.VESTIGE_API_URL || 'https://free-api.vestige.fi';
+
+const ALGO_API_TOKEN = process.env.ALGO_API_TOKEN;
+const TINYMAN_API_TOKEN = process.env.TINYMAN_API_TOKEN;
+const PACT_API_TOKEN = process.env.PACT_API_TOKEN;
+const VESTIGE_API_TOKEN = process.env.VESTIGE_API_TOKEN;
+
+function buildHeaders(token) {
+  const headers = { Accept: 'application/json' };
+  if (token) headers['X-API-Key'] = token;
+  return headers;
+}
+
+async function forward(req, res, baseUrl, token) {
+  try {
+    const url = `${baseUrl}${req.path}`;
+    const options = {
+      method: req.method,
+      headers: { ...buildHeaders(token), ...req.headers },
+      params: req.query,
+      data: req.body
+    };
+    const response = await axios(url, options);
+    res.status(response.status).json(response.data);
+  } catch (err) {
+    const status = err.response?.status || 500;
+    res.status(status).json({ error: err.message });
+  }
+}
+
+app.use(express.json());
+
+app.use('/api/tinyman', (req, res) => forward(req, res, TINYMAN_API_URL, TINYMAN_API_TOKEN || ALGO_API_TOKEN));
+app.use('/api/pact', (req, res) => forward(req, res, PACT_API_URL, PACT_API_TOKEN || ALGO_API_TOKEN));
+app.use('/api/vestige', (req, res) => forward(req, res, VESTIGE_API_URL, VESTIGE_API_TOKEN || ALGO_API_TOKEN));
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "algoranarchy-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "axios": "^1.6.0",
+    "dotenv": "^16.4.5"
+  }
+}


### PR DESCRIPTION
## Summary
- create `server/` Express app for Tinyman, Pact and Vestige proxying
- allow Algorand API tokens via environment variables without `VITE_`
- document how to run the backend locally and in production

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bacc9d20c832eb96f85c650275222