### PR TITLE
Enable live Algorand data

### DIFF
--- a/src/components/BlocksTable.tsx
+++ b/src/components/BlocksTable.tsx
@@ -42,41 +42,7 @@ export const BlocksTable: React.FC = () => {
     }
   };
 
-  // Generate mock blocks if no real data is available
-  const getDisplayBlocks = () => {
-    if (latestBlocks.length > 0) {
-      return latestBlocks;
-    }
-    
-    // Generate mock blocks based on current node status
-    const currentRound = nodeStatus?.['last-round'] || 50789234;
-    const mockBlocks = [];
-    
-    for (let i = 0; i < 5; i++) {
-      mockBlocks.push({
-        round: currentRound - i,
-        'genesis-hash': 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-        'genesis-id': 'mainnet-v1.0',
-        'previous-block-hash': `${Math.random().toString(36).substring(2, 8)}...${Math.random().toString(36).substring(2, 8)}`,
-        rewards: {
-          'fee-sink': 'A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE',
-          'rewards-calculation-round': currentRound - i,
-          'rewards-level': 0,
-          'rewards-pool': 'A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE',
-          'rewards-rate': 0,
-          'rewards-residue': 0
-        },
-        seed: 'mock-seed',
-        timestamp: Math.floor(Date.now() / 1000) - (i * 45),
-        'transactions-root': 'mock-tx-root',
-        'txn-counter': Math.floor(Math.random() * 200) + 50
-      });
-    }
-    
-    return mockBlocks;
-  };
-
-  const displayBlocks = getDisplayBlocks();
+  const displayBlocks = latestBlocks;
 
   return (
     <section id="blocks" className="mb-16">
@@ -137,7 +103,7 @@ export const BlocksTable: React.FC = () => {
                     {block['previous-block-hash'] ? AlgorandService.shortenAddress(block['previous-block-hash'], 5) : 'N/A'}
                   </td>
                   <td className="px-6 py-4">
-                    {(Math.random() * 2 + 6).toFixed(2)} ALGO
+                    {block.rewards ? `${AlgorandService.formatAlgoAmount(block.rewards['rewards-rate'] || 0)} ALGO` : 'N/A'}
                   </td>
                   <td className="px-6 py-4">
                     <button 

--- a/src/services/algorandService.ts
+++ b/src/services/algorandService.ts
@@ -95,8 +95,8 @@ export class AlgorandService {
         'time-since-last-round': Number(status.timeSinceLastRound || 0)
       };
     } catch (error) {
-      console.warn('Failed to fetch node status, using mock data:', error);
-      return this.getMockNodeStatus();
+      console.warn('Failed to fetch node status:', error);
+      throw error;
     }
   }
 
@@ -110,8 +110,8 @@ export class AlgorandService {
         total_money: Number(supply.totalMoney || 0)
       };
     } catch (error) {
-      console.warn('Failed to fetch ledger supply, using mock data:', error);
-      return this.getMockLedgerSupply();
+      console.warn('Failed to fetch ledger supply:', error);
+      throw error;
     }
   }
 
@@ -130,23 +130,22 @@ export class AlgorandService {
             const block = await this.getBlock(round);
             blocks.push(block);
           } catch (blockError) {
-            // If individual block fails, create mock block
-            blocks.push(this.getMockBlock(round));
+            console.warn(`Failed to fetch block ${round}:`, blockError);
           }
         }
       }
 
       return blocks;
     } catch (error) {
-      console.warn('Failed to fetch latest blocks, using mock data:', error);
-      return this.getMockBlocks(count);
+      console.warn('Failed to fetch latest blocks:', error);
+      return [];
     }
   }
 
   static async getBlock(round: number): Promise<Block> {
     this.initialize();
     try {
-      const blockResponse = await this.algodClient.block(round).do();
+      const blockResponse = await this.indexerClient.lookupBlock(round).do();
       const block = blockResponse.block;
 
       return {
@@ -169,8 +168,8 @@ export class AlgorandService {
         transactions: block.txns || []
       };
     } catch (error) {
-      console.warn(`Failed to fetch block ${round}, using mock data:`, error);
-      return this.getMockBlock(round);
+      console.warn(`Failed to fetch block ${round}:`, error);
+      throw error;
     }
   }
 

--- a/src/store/algorandStore.ts
+++ b/src/store/algorandStore.ts
@@ -81,7 +81,7 @@ export const useAlgorandStore = create<AlgorandState>((set, get) => ({
   fetchLatestBlocks: async () => {
     set({ isLoadingBlocks: true, error: null });
     try {
-      const blocks = await AlgorandService.getLatestBlocks(5);
+      const blocks = await AlgorandService.getLatestBlocks(10);
       set({ latestBlocks: blocks, isLoadingBlocks: false });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Failed to fetch latest blocks';
@@ -128,7 +128,7 @@ export const useAlgorandStore = create<AlgorandState>((set, get) => ({
   fetchTopAssets: async () => {
     set({ isLoadingAssets: true, error: null });
     try {
-      const assets = await AlgorandService.getTopAssets(8);
+      const assets = await AlgorandService.getTopAssets(6);
       set({ topAssets: assets, isLoadingAssets: false });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Failed to fetch top assets';


### PR DESCRIPTION
## Summary
- use indexer for block data and remove mocked responses
- poll ALGO price in the stats panel
- fetch 10 blocks and show real rewards
- show top 6 ASA assets with price data

## Testing
- `npm run lint` *(fails: cannot find ESLint modules)*
- `npm run build` *(fails: vite not installed offline)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6852f4b4e8e8832eb74ae9a0a563aa88