### PR TITLE
Switch to VITE_ENVIRONMENT network variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-# Algorand Network Configuration
+# Algorand Environment Configuration
 VITE_ALGO_API_TOKEN=your_algorand_api_token_here
-VITE_ALGO_NETWORK=mainnet
+# Set to "testnet" to use Algorand testnet endpoints
+VITE_ENVIRONMENT=development
 VITE_ALGO_NODE_MAINNET=https://mainnet-api.4160.nodely.io
 VITE_ALGO_INDEXER_MAINNET=https://mainnet-idx.4160.nodely.io
 VITE_ALGO_NODE_TESTNET=https://testnet-api.4160.nodely.io
@@ -30,7 +31,6 @@ VITE_POLL_INTERVAL_MS=30000
 
 # Development Settings
 VITE_DEBUG_MODE=true
-VITE_ENVIRONMENT=development
 
 # Analytics (Optional)
 VITE_GOOGLE_ANALYTICS_ID=your_ga_id_here

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ ALGORANARCHY breaks the mold of traditional blockchain explorers with a punk roc
    ```env
    # CRITICAL: Get this from Nodely.io or AlgoNode.io
    VITE_ALGO_API_TOKEN=your_algorand_api_token
-   # Network selection: mainnet or testnet
-   VITE_ALGO_NETWORK=mainnet
+   # Environment: production or testnet
+   VITE_ENVIRONMENT=production
    VITE_ALGO_NODE_MAINNET=https://mainnet-api.4160.nodely.io
    VITE_ALGO_INDEXER_MAINNET=https://mainnet-idx.4160.nodely.io
    VITE_ALGO_NODE_TESTNET=https://testnet-api.4160.nodely.io
@@ -168,7 +168,7 @@ The application is deployed on Netlify with the following environment variables 
 
 ```env
 VITE_ALGO_API_TOKEN=your_algorand_api_token
-VITE_ALGO_NETWORK=mainnet
+VITE_ENVIRONMENT=production
 VITE_ALGO_NODE_MAINNET=https://mainnet-api.4160.nodely.io
 VITE_ALGO_INDEXER_MAINNET=https://mainnet-idx.4160.nodely.io
 VITE_ALGO_NODE_TESTNET=https://testnet-api.4160.nodely.io
@@ -177,7 +177,6 @@ VITE_MORALIS_API_KEY=your_moralis_api_key
 VITE_COINGECKO_API_KEY=your_coingecko_api_key
 VITE_PERA_WALLET_BRIDGE_URL=https://wallet-connect.perawallet.app
 VITE_DEBUG_MODE=false
-VITE_ENVIRONMENT=production
 ```
 
 For deployment instructions, see our [Deployment Guide](docs/DEPLOYMENT.md).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,8 @@ function App() {
   useEffect(() => {
     // Initialize data on app load
     console.log('🚀 Initializing Enhanced Algoranarchy app...');
-    const network = (import.meta.env.VITE_ALGO_NETWORK || 'mainnet').toLowerCase();
+    const environment = (import.meta.env.VITE_ENVIRONMENT || '').toLowerCase();
+    const network = environment === 'testnet' ? 'testnet' : 'mainnet';
     const nodeUrl = network === 'testnet'
       ? import.meta.env.VITE_ALGO_NODE_TESTNET
       : import.meta.env.VITE_ALGO_NODE_MAINNET;

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -64,7 +64,7 @@ export const DebugPanel: React.FC = () => {
   const checkEnvironmentVariables = () => {
     const envVars = {
       'VITE_ALGO_API_TOKEN': import.meta.env.VITE_ALGO_API_TOKEN ? 'SET ✅' : 'NOT SET ❌',
-      'VITE_ALGO_NETWORK': import.meta.env.VITE_ALGO_NETWORK || 'mainnet',
+      'VITE_ENVIRONMENT': import.meta.env.VITE_ENVIRONMENT || 'production',
       'VITE_ALGO_NODE_MAINNET': import.meta.env.VITE_ALGO_NODE_MAINNET || 'NOT SET ❌',
       'VITE_ALGO_INDEXER_MAINNET': import.meta.env.VITE_ALGO_INDEXER_MAINNET || 'NOT SET ❌',
       'VITE_ALGO_NODE_TESTNET': import.meta.env.VITE_ALGO_NODE_TESTNET || 'NOT SET ❌',

--- a/src/services/algorandService.ts
+++ b/src/services/algorandService.ts
@@ -2,7 +2,8 @@ import algosdk from 'algosdk';
 import type { AlgorandAccount, Block, NodeStatus, LedgerSupply, AssetInfo, Transaction } from '../types/algorand';
 
 const API_TOKEN = import.meta.env.VITE_ALGO_API_TOKEN || '';
-const NETWORK = (import.meta.env.VITE_ALGO_NETWORK || 'mainnet').toLowerCase();
+const ENVIRONMENT = (import.meta.env.VITE_ENVIRONMENT || '').toLowerCase();
+const NETWORK = ENVIRONMENT === 'testnet' ? 'testnet' : 'mainnet';
 const MAINNET_NODE = import.meta.env.VITE_ALGO_NODE_MAINNET || 'https://mainnet-api.4160.nodely.io';
 const MAINNET_INDEXER = import.meta.env.VITE_ALGO_INDEXER_MAINNET || 'https://mainnet-idx.4160.nodely.io';
 const TESTNET_NODE = import.meta.env.VITE_ALGO_NODE_TESTNET || 'https://testnet-api.4160.nodely.io';


### PR DESCRIPTION
## Summary
- replace `VITE_ALGO_NETWORK` with `VITE_ENVIRONMENT`
- adapt logic for default MAINNET unless set to `testnet`
- update debug panel and example environment file
- document new variable in README

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d22458748832e9c9e02810abbbbf7